### PR TITLE
register setting plugins.xbib.icu.enabled via getSettings()

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/bundle/BundlePlugin.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/bundle/BundlePlugin.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.index.analysis.AnalyzerProvider;
@@ -71,10 +72,12 @@ import org.xbib.elasticsearch.rest.action.isbnformat.RestISBNFormatterAction;
 import org.xbib.elasticsearch.rest.action.langdetect.RestLangdetectAction;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -92,6 +95,11 @@ public class BundlePlugin extends Plugin implements AnalysisPlugin, MapperPlugin
 
     public BundlePlugin(Settings settings) {
         this.settings = settings;
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(new Setting<>("plugins.xbib.icu.enabled", "true", Function.identity(), Setting.Property.NodeScope));
     }
 
     @Override


### PR DESCRIPTION
Without registering the setting it is not possible to disable ICU in elasticsearch 5.x. I need the icu_collation filter which is in the analysis-icu plugin which clashes with elasticsearch-plugin-bundle: `(org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: char_filter for name [icu_normalizer] already registered)`