### PR TITLE
#47 Can't set languages for fields of type langdetect when profile is shorttext

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/bundle/common/langdetect/LangdetectService.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/bundle/common/langdetect/LangdetectService.java
@@ -111,7 +111,6 @@ public class LangdetectService {
     private static final Pattern word = Pattern.compile("[\\P{IsWord}]", Pattern.UNICODE_CHARACTER_CLASS);
 
     private static final Settings DEFAULT_SETTINGS = Settings.builder()
-            .putList("languages", DEFAULT_LANGUAGES)
             .putList("languages_short_text", DEFAULT_LANGUAGES_SHORT_TEXT)
             .build();
 
@@ -170,7 +169,7 @@ public class LangdetectService {
             return;
         }
         List<String> keys = "shorttext".equals(profile) ?
-                settings.getAsList("languages_short_text", Arrays.asList(DEFAULT_LANGUAGES_SHORT_TEXT)) :
+                settings.getAsList("languages_short_text", settings.getAsList("languages", Arrays.asList(DEFAULT_LANGUAGES_SHORT_TEXT))) :
                 settings.getAsList("languages", Arrays.asList(DEFAULT_LANGUAGES));
         int index = 0;
         int size = keys.size();


### PR DESCRIPTION
In this fix we first try to get the value of `languages` list (if available) before using the default value for `languages_short_text`. We don't need initialization of `languages` in `DEFAULT_SETTINGS` because we provide a default value when getting the languages (<https://github.com/jprante/elasticsearch-plugin-bundle/blob/e75891afbc280de6e5b924c57fd029642b268777/src/main/java/org/xbib/elasticsearch/plugin/bundle/common/langdetect/LangdetectService.java#L174>). By doing that we ensure that `DEFAULT_LANGUAGES_SHORT_TEXT` will be used if no configuration is provided (default constructor). The only drawback of this approach is if someone provide settings that contains `languages` but not contains `languages_short_text` and actually want to use `DEFAULT_LANGUAGES_SHORT_TEXT`. This case could be avoided if the default constructor is used in the situation.

However test case needs to be created...